### PR TITLE
Disable Refined Iron Chicken

### DIFF
--- a/config/chickens/morechickens.json
+++ b/config/chickens/morechickens.json
@@ -650,7 +650,7 @@
   },
   "morechickens:refinedironchicken": {
     "Name": "refinedironchicken",
-    "Is Enabled": true,
+    "Is Enabled": false,
     "Lay Coefficient": 1.0,
     "Lay Item": "ic2:ingot:7",
     "Drop Item": "ic2:ingot:7",


### PR DESCRIPTION
Refined Iron Chickens are very annoying in the Chicken Breeder.
As the ingots can only be used in IronChests recipes (idk why), there is no point in keeping the affiliated chicken.