### PR TITLE
fix invalid entries in lootbag blacklist

### DIFF
--- a/config/lootbags.cfg
+++ b/config/lootbags.cfg
@@ -85,7 +85,7 @@ recycler {
         betterbuilderswands:wandIron:0
         betterbuilderswands:wandStone:0
         harvestcraft:juicerItem:0
-        integrateddynamics:menrilSapling:0
+        integrateddynamics:menril_sapling:0
         minecraft:brown_mushroom:0
         minecraft:carrot:0
         minecraft:dirt:0
@@ -122,12 +122,10 @@ recycler {
         minecraft:sugar:0
         minecraft:wheat:0
         minecraft:gravel:0
-        minicoal:miniCharcoal:0
-        minicoal:miniCoal:0
         minecraft:sand:0
         chesttransporter:chesttransporter:0
-        minecraft:string
-        minecraft:coal
+        minecraft:string:0
+        minecraft:coal:0
      >
 
     # Whitelist an item to be recyclable.  The entry must be in the form <modid>:<itemname>:<damage>:<weighting>:[<nbt data (seriously don't try to make this by hand)> (optional)]  The weight is as though the item was added to a bag, but the items whitelisted are not added to any loot bags.


### PR DESCRIPTION
These items were just creating errors in the log from what I could tell.